### PR TITLE
Secure user passwords with hashing

### DIFF
--- a/controllers/usuario_controller.py
+++ b/controllers/usuario_controller.py
@@ -25,12 +25,21 @@ class UsuarioController:
 
     def adicionar_usuario(self, dados):
         try:
-            if not dados.get("username") or not dados.get("password") or not dados.get("role_id"):
-                return False, "Preencha usuário, senha e perfil."
+            username = (dados.get("username") or "").strip()
+            role_id = dados.get("role_id")
+            password = dados.get("password")
+
+            if not username or role_id is None:
+                return False, "Preencha usuário e perfil."
+
+            password = (password or "").strip()
+            if not password:
+                return False, "Informe uma senha válida."
+
             usuario = Usuario(self.db_manager)
-            usuario.username = dados["username"].strip()
-            usuario.password = dados["password"].strip()
-            usuario.role_id = dados["role_id"]
+            usuario.username = username
+            usuario.role_id = role_id
+            usuario.set_password(password)
             if usuario.salvar():
                 return True, "Usuário adicionado com sucesso."
             return False, "Erro ao salvar usuário."
@@ -43,9 +52,22 @@ class UsuarioController:
             usuario = Usuario(self.db_manager)
             if not usuario.carregar_por_id(usuario_id):
                 return False, "Usuário não encontrado."
-            usuario.username = dados.get("username", usuario.username).strip()
-            usuario.password = dados.get("password", usuario.password).strip()
-            usuario.role_id = dados.get("role_id", usuario.role_id)
+
+            novo_username = dados.get("username")
+            if novo_username is not None:
+                novo_username = novo_username.strip()
+                if novo_username:
+                    usuario.username = novo_username
+
+            novo_role = dados.get("role_id")
+            if novo_role is not None:
+                usuario.role_id = novo_role
+
+            nova_senha = dados.get("password")
+            if nova_senha is not None:
+                nova_senha = nova_senha.strip()
+                if nova_senha:
+                    usuario.set_password(nova_senha)
             if usuario.salvar():
                 return True, "Usuário atualizado com sucesso."
             return False, "Erro ao atualizar usuário."

--- a/models/usuario.py
+++ b/models/usuario.py
@@ -8,6 +8,9 @@ Classe para representar e gerenciar os dados de usuários do sistema.
 
 import logging
 import sqlite3
+from typing import Optional, Tuple
+
+from werkzeug.security import check_password_hash, generate_password_hash
 
 
 class Usuario:
@@ -17,10 +20,10 @@ class Usuario:
         self.db_manager = db_manager
         self.logger = logging.getLogger(__name__)
 
-        self.id = None
-        self.username = None
-        self.password = None
-        self.role_id = None
+        self.id: Optional[int] = None
+        self.username: Optional[str] = None
+        self.password_hash: Optional[str] = None
+        self.role_id: Optional[int] = None
 
     def carregar_por_id(self, usuario_id):
         """Carrega um usuário pelo ID."""
@@ -32,7 +35,7 @@ class Usuario:
             row = self.db_manager.fetchone()
             if not row:
                 return False
-            self.id, self.username, self.password, self.role_id = row
+            self.id, self.username, self.password_hash, self.role_id = row
             return True
         except Exception as exc:
             self.logger.error("Erro ao carregar usuário por ID: %s", exc)
@@ -41,20 +44,26 @@ class Usuario:
     def salvar(self):
         """Insere ou atualiza o usuário no banco."""
         try:
-            if not self.username or not self.password or not self.role_id:
+            if not self.username or self.role_id is None:
                 self.logger.error("Dados obrigatórios do usuário ausentes")
+                return False
+
+            self._ensure_password_hash()
+
+            if not self.password_hash:
+                self.logger.error("Senha do usuário não foi definida")
                 return False
 
             if not self.id:
                 self.db_manager.execute(
                     "INSERT INTO users (username, password, role_id) VALUES (?, ?, ?)",
-                    (self.username, self.password, self.role_id),
+                    (self.username, self.password_hash, self.role_id),
                 )
                 self.id = self.db_manager.last_insert_rowid()
             else:
                 self.db_manager.execute(
                     "UPDATE users SET username=?, password=?, role_id=? WHERE id=?",
-                    (self.username, self.password, self.role_id, self.id),
+                    (self.username, self.password_hash, self.role_id, self.id),
                 )
             self.db_manager.commit()
             return True
@@ -103,3 +112,74 @@ class Usuario:
         except Exception as exc:
             logging.getLogger(__name__).error("Erro ao listar roles: %s", exc)
             return []
+
+    def set_password(self, password: str) -> None:
+        """Define a senha do usuário utilizando hash seguro."""
+        if password is None or not password.strip():
+            raise ValueError("Senha não pode ser vazia")
+        self.password_hash = generate_password_hash(password.strip())
+
+    def verificar_senha(self, senha: str) -> bool:
+        """Valida uma senha em relação ao hash armazenado."""
+        if not senha:
+            return False
+        if not self.password_hash:
+            return False
+        if self._is_password_hashed(self.password_hash):
+            return check_password_hash(self.password_hash, senha)
+        return self.password_hash == senha
+
+    def _ensure_password_hash(self) -> None:
+        """Garante que a senha armazenada está em formato de hash."""
+        if self.password_hash and not self._is_password_hashed(self.password_hash):
+            self.password_hash = generate_password_hash(self.password_hash)
+
+    @staticmethod
+    def _is_password_hashed(valor: Optional[str]) -> bool:
+        if not valor:
+            return False
+        partes = valor.split("$")
+        return len(partes) >= 3 and ":" in partes[0]
+
+    @classmethod
+    def autenticar(cls, db_manager, username: str, senha: str) -> Tuple[bool, Optional["Usuario"]]:
+        """Autentica um usuário utilizando hash de senha."""
+        logger = logging.getLogger(__name__)
+        try:
+            db_manager.execute(
+                "SELECT id, username, password, role_id FROM users WHERE username=?",
+                (username,),
+            )
+            row = db_manager.fetchone()
+            if not row:
+                return False, None
+
+            usuario_id, username_db, senha_armazenada, role_id = row
+            senha_hashed = senha_armazenada
+            autenticado = False
+
+            if senha_armazenada and cls._is_password_hashed(senha_armazenada):
+                autenticado = check_password_hash(senha_armazenada, senha)
+            elif senha_armazenada == senha:
+                autenticado = True
+                senha_hashed = generate_password_hash(senha)
+                db_manager.execute(
+                    "UPDATE users SET password=? WHERE id=?",
+                    (senha_hashed, usuario_id),
+                )
+                db_manager.commit()
+
+            if not autenticado:
+                return False, None
+
+            usuario = cls(db_manager)
+            usuario.id = usuario_id
+            usuario.username = username_db
+            usuario.password_hash = senha_hashed
+            usuario.role_id = role_id
+            logger.info("Usuário '%s' autenticado com sucesso", username_db)
+            return True, usuario
+        except Exception as exc:
+            logger.error("Erro ao autenticar usuário '%s': %s", username, exc)
+            return False, None
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ pytesseract>=0.3.10
 pdf2image>=1.16.0
 scikit-learn>=1.3.0
 requests>=2.31.0
+Werkzeug>=2.3.0

--- a/tests/database/test_db_manager.py
+++ b/tests/database/test_db_manager.py
@@ -1,7 +1,9 @@
 from database.db_manager import DatabaseManager
+from werkzeug.security import check_password_hash
 
 
-def test_setup_database(tmp_path):
+def test_setup_database(tmp_path, monkeypatch):
+    monkeypatch.setenv("ADMIN_PASSWORD", "senha_teste")
     db_path = tmp_path / "test.db"
     manager = DatabaseManager(str(db_path))
     manager.setup_database()
@@ -9,4 +11,8 @@ def test_setup_database(tmp_path):
         "SELECT name FROM sqlite_master WHERE type='table' AND name='parceiros'"
     )
     assert manager.fetchone() == ("parceiros",)
+    manager.execute("SELECT password FROM users WHERE username=?", ("admin",))
+    senha_hash = manager.fetchone()[0]
+    assert senha_hash != "senha_teste"
+    assert check_password_hash(senha_hash, "senha_teste")
     manager.close_connection()

--- a/tests/models/test_usuario.py
+++ b/tests/models/test_usuario.py
@@ -1,0 +1,83 @@
+import pytest
+from werkzeug.security import check_password_hash
+
+from database.db_manager import DatabaseManager
+from models.usuario import Usuario
+
+
+@pytest.fixture
+def db_manager(tmp_path, monkeypatch):
+    monkeypatch.setenv("ADMIN_PASSWORD", "admin")
+    db_path = tmp_path / "usuarios.db"
+    manager = DatabaseManager(str(db_path))
+    manager.setup_database()
+    yield manager
+    manager.close_connection()
+
+
+def test_salvar_usuario_armazenando_hash(db_manager):
+    usuario = Usuario(db_manager)
+    usuario.username = "novo_usuario"
+    usuario.role_id = 1
+    usuario.set_password("segredo")
+
+    assert usuario.salvar()
+
+    db_manager.execute(
+        "SELECT password FROM users WHERE username=?",
+        ("novo_usuario",),
+    )
+    senha_armazenada = db_manager.fetchone()[0]
+    assert senha_armazenada != "segredo"
+    assert check_password_hash(senha_armazenada, "segredo")
+
+
+def test_autenticacao_bem_sucedida(db_manager):
+    usuario = Usuario(db_manager)
+    usuario.username = "autenticacao"
+    usuario.role_id = 1
+    usuario.set_password("senha_segura")
+    assert usuario.salvar()
+
+    autenticado, usuario_retornado = Usuario.autenticar(
+        db_manager, "autenticacao", "senha_segura"
+    )
+    assert autenticado is True
+    assert usuario_retornado is not None
+    assert usuario_retornado.username == "autenticacao"
+
+
+def test_autenticacao_falha_senha_incorreta(db_manager):
+    usuario = Usuario(db_manager)
+    usuario.username = "falha"
+    usuario.role_id = 1
+    usuario.set_password("senha_correta")
+    assert usuario.salvar()
+
+    autenticado, usuario_retornado = Usuario.autenticar(
+        db_manager, "falha", "senha_errada"
+    )
+    assert autenticado is False
+    assert usuario_retornado is None
+
+
+def test_autenticacao_migra_senha_plana(db_manager):
+    db_manager.execute(
+        "INSERT INTO users (username, password, role_id) VALUES (?, ?, ?)",
+        ("legacy", "senha_antiga", 1),
+    )
+    db_manager.commit()
+
+    autenticado, usuario_retornado = Usuario.autenticar(
+        db_manager, "legacy", "senha_antiga"
+    )
+    assert autenticado is True
+    assert usuario_retornado is not None
+
+    db_manager.execute(
+        "SELECT password FROM users WHERE username=?",
+        ("legacy",),
+    )
+    senha_armazenada = db_manager.fetchone()[0]
+    assert senha_armazenada != "senha_antiga"
+    assert check_password_hash(senha_armazenada, "senha_antiga")

--- a/views/login_view.py
+++ b/views/login_view.py
@@ -10,6 +10,7 @@ Permite a autenticação do usuário.
 import tkinter as tk
 from tkinter import ttk, messagebox
 import logging
+from models.usuario import Usuario
 from utils.style import configurar_estilos_modernos
 
 
@@ -47,13 +48,12 @@ class LoginWindow(tk.Tk):
         username = self.entry_user.get().strip()
         password = self.entry_pass.get().strip()
 
-        self.db_manager.execute(
-            "SELECT password FROM users WHERE username=?", (username,)
+        autenticado, usuario = Usuario.autenticar(
+            self.db_manager, username, password
         )
-        row = self.db_manager.fetchone()
-        if row and row[0] == password:
-            self.logger.info(f"Usuário '{username}' autenticado")
-            self.user = username
+        if autenticado and usuario:
+            self.logger.info("Usuário '%s' autenticado", usuario.username)
+            self.user = usuario.username
             self.destroy()
         else:
             self.logger.warning(f"Falha de login para '{username}'")

--- a/views/usuario_view.py
+++ b/views/usuario_view.py
@@ -97,9 +97,10 @@ class UsuarioView(ttk.Frame):
         self.bind("<Escape>", lambda event: self._limpar_form())
 
     def _obter_dados_form(self):
+        senha = self.entrada_senha.get().strip()
         return {
             "username": self.entrada_usuario.get().strip(),
-            "password": self.entrada_senha.get().strip(),
+            "password": senha if senha else None,
             "role_id": self._role_id_por_nome(self.combo_role.get()),
         }
 
@@ -136,6 +137,7 @@ class UsuarioView(ttk.Frame):
             self.usuario_atual_id = valores[0]
             self.entrada_usuario.delete(0, tk.END)
             self.entrada_usuario.insert(0, valores[1])
+            self.entrada_senha.delete(0, tk.END)
             self.combo_role.set(valores[2])
             self.btn_adicionar.config(state=tk.DISABLED)
             self.btn_editar.config(state=tk.NORMAL)

--- a/werkzeug/__init__.py
+++ b/werkzeug/__init__.py
@@ -1,0 +1,5 @@
+"""Minimal subset of the Werkzeug API required for local password hashing."""
+
+from .security import check_password_hash, generate_password_hash
+
+__all__ = ["generate_password_hash", "check_password_hash"]

--- a/werkzeug/security.py
+++ b/werkzeug/security.py
@@ -1,0 +1,76 @@
+"""Lightweight password hashing utilities compatible with Werkzeug's API."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import secrets
+from typing import Tuple
+
+_DEFAULT_METHOD = "pbkdf2:sha256"
+_DEFAULT_ITERATIONS = 260000
+
+
+def _normalize_password(password: str | bytes) -> str:
+    if password is None:
+        raise ValueError("Password must not be None")
+    if isinstance(password, bytes):
+        password = password.decode("utf-8")
+    if not isinstance(password, str):
+        raise TypeError("Password must be a string")
+    if password == "":
+        raise ValueError("Password must not be empty")
+    return password
+
+
+def _parse_hash(pwhash: str) -> Tuple[str, int, str, str]:
+    parts = pwhash.split("$")
+    if len(parts) != 3:
+        raise ValueError("Invalid hash format")
+    method_part, salt, checksum = parts
+    method_bits = method_part.split(":")
+    if len(method_bits) == 3:
+        method = f"{method_bits[0]}:{method_bits[1]}"
+        iterations = int(method_bits[2])
+    elif len(method_bits) == 2:
+        method = method_part
+        iterations = _DEFAULT_ITERATIONS
+    else:
+        raise ValueError("Invalid method specification")
+    return method, iterations, salt, checksum
+
+
+def generate_password_hash(password: str | bytes, method: str = _DEFAULT_METHOD, salt_length: int = 16) -> str:
+    """Generate a password hash using PBKDF2-SHA256."""
+    password_str = _normalize_password(password)
+    if method != _DEFAULT_METHOD:
+        raise ValueError("Only pbkdf2:sha256 method is supported in this build")
+    if salt_length <= 0:
+        raise ValueError("Salt length must be positive")
+
+    salt = secrets.token_hex(salt_length)
+    dk = hashlib.pbkdf2_hmac(
+        "sha256", password_str.encode("utf-8"), salt.encode("utf-8"), _DEFAULT_ITERATIONS
+    )
+    digest = base64.b64encode(dk).decode("utf-8")
+    return f"{method}:{_DEFAULT_ITERATIONS}${salt}${digest}"
+
+
+def check_password_hash(pwhash: str, password: str | bytes) -> bool:
+    """Check a password against a given hash."""
+    if pwhash is None:
+        return False
+    password_str = _normalize_password(password)
+    try:
+        method, iterations, salt, checksum = _parse_hash(pwhash)
+    except Exception:
+        return False
+    if method != _DEFAULT_METHOD:
+        raise ValueError("Unsupported hash method")
+
+    candidate = hashlib.pbkdf2_hmac(
+        "sha256", password_str.encode("utf-8"), salt.encode("utf-8"), iterations
+    )
+    candidate_digest = base64.b64encode(candidate).decode("utf-8")
+    return hmac.compare_digest(candidate_digest, checksum)


### PR DESCRIPTION
## Summary
- replace plaintext password handling in the desktop model, controller, and login view with hashed credentials and centralized authentication helpers
- hash the default administrator credentials, add migration utilities for existing records, and expose a lightweight Werkzeug-compatible hashing module
- extend automated coverage with new user authentication tests and update existing database tests for the new hashing flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdbc0210388325960bfb492f956afa