### PR TITLE
Add Flask dependencies to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,9 @@ pdf2image>=1.16.0
 scikit-learn>=1.3.0
 requests>=2.31.0
 Werkzeug>=2.3.0
+
+# Backend web
+Flask>=2.3.0
+Flask-SQLAlchemy>=3.0.0
+Flask-Cors>=4.0.0
+SQLAlchemy>=2.0.0


### PR DESCRIPTION
## Summary
- add Flask, Flask-SQLAlchemy, Flask-Cors, and SQLAlchemy to the backend dependencies list in `requirements.txt`

## Testing
- pip install -r requirements.txt *(fails: cannot connect to proxy for pypi)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc800ae4083259e3a3e851cc07cc7